### PR TITLE
SIXJ-115 클라이언트 ResponseType 수정

### DIFF
--- a/client/ios/Runner/Base.lproj/Main.storyboard
+++ b/client/ios/Runner/Base.lproj/Main.storyboard
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Flutter View Controller-->
@@ -14,13 +16,14 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="-16" y="-6"/>
         </scene>
     </scenes>
 </document>

--- a/client/lib/data/remote/http/common/dto/response_envelope.dart
+++ b/client/lib/data/remote/http/common/dto/response_envelope.dart
@@ -12,8 +12,8 @@ typedef ResponseTypeToObject<T> = T Function();
 
 @immutable
 class ResponseType {
-  static const ok = ResponseType("ok");
-  static const error = ResponseType("error");
+  static const ok = ResponseType("OK");
+  static const error = ResponseType("ERROR");
 
   final String value;
 


### PR DESCRIPTION
BE에서 넘겨주는 Response 타입과 FE의 선언된 타입 스트링이 다른 오류를 수정하였습니다.

[server/api/endpoint/v1/ResponseEnvelopeV1.kt](https://github.com/sirloin-dev/meatplatform-sandbox/blob/main/server/api-main/src/main/kotlin/com/sirloin/sandbox/server/api/endpoint/v1/ResponseEnvelopeV1.kt)
``` kt
 companion object {
        const val DESC_TYPE = "응답의 유형을 나타냅니다. 'OK' 또는 'ERROR' 로 표시합니다."
        const val DESC_TIMESTAMP = "ISO 8601 표준 포맷으로 나타낸 응답 발생 시간입니다. 시간대는 UTC 기준입니다."
        const val DESC_BODY = "응답의 실제 내용을 담고 있는 객체입니다."

        fun <T> ok(payload: T?) = OkResponseV1(payload)

        fun error(exception: MtException) = ErrorResponseV1.create(exception)
    }

    enum class Type(@JsonValue val value: String) {
        OK("OK"),
        ERROR("ERROR");

        companion object {
            @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
            @JvmStatic
            fun from(value: String) = values().firstOrNull { it.value == value }
                ?: throw IllegalArgumentException("Cannot convert '${value}' as Response type")
        }
    }
```
응답의 유형을 결정하는 사항이 위의 항목에서 설명되었기 때문에, FE의 ResponseType이 BE에서 넘겨주는 유형을 만족시켜야 한다고 판단하였습니다.